### PR TITLE
update newly working test. Cleaner output for MSVC errors

### DIFF
--- a/src/Compilation.zig
+++ b/src/Compilation.zig
@@ -1166,7 +1166,7 @@ test "target size/align tests" {
     };
 
     try std.testing.expectEqual(@as(u64, 8), tt.sizeof(&comp).?);
-    try std.testing.expectEqual(@as(u64, 8), tt.alignof(&comp)); // TODO should be 4
+    try std.testing.expectEqual(@as(u64, 4), tt.alignof(&comp));
 
     const arm = std.Target.Cpu.Arch.arm;
     comp.target.cpu = std.Target.Cpu.Model.toCpu(&std.Target.arm.cpu.cortex_r4, arm);

--- a/src/Diagnostics.zig
+++ b/src/Diagnostics.zig
@@ -2182,10 +2182,12 @@ pub fn fatalNoSrc(diag: *Diagnostics, comptime fmt: []const u8, args: anytype) e
 
 pub fn render(comp: *Compilation) void {
     if (comp.diag.list.items.len == 0) return;
-    var m = MsgWriter.init(comp.diag.color);
+    var m = defaultMsgWriter(comp);
     defer m.deinit();
-
     renderExtra(comp, &m);
+}
+pub fn defaultMsgWriter(comp: *const Compilation) MsgWriter {
+    return MsgWriter.init(comp.diag.color);
 }
 
 /// This is a workaround for a stage1 bug when constructing an anonymous struct with a
@@ -2206,94 +2208,7 @@ pub fn renderExtra(comp: *Compilation, m: anytype) void {
             .off => continue, // happens if an error is added before it is disabled
             .default => unreachable,
         }
-
-        var line: ?[]const u8 = null;
-        var end_with_splice = false;
-        const width = if (msg.loc.id != .unused) blk: {
-            var loc = msg.loc;
-            switch (msg.tag) {
-                .escape_sequence_overflow,
-                .invalid_universal_character,
-                .non_standard_escape_char,
-                // use msg.extra.unsigned for index into string literal
-                => loc.byte_offset += @truncate(u32, msg.extra.unsigned),
-                else => {},
-            }
-            const source = comp.getSource(loc.id);
-            var line_col = source.lineCol(loc);
-            line = line_col.line;
-            end_with_splice = line_col.end_with_splice;
-            if (msg.tag == .backslash_newline_escape) {
-                line = line_col.line[0 .. line_col.col - 1];
-                line_col.col += 1;
-                line_col.width += 1;
-            }
-            m.location(source.path, line_col.line_no, line_col.col);
-            break :blk line_col.width;
-        } else 0;
-
-        m.start(msg.kind);
-        @setEvalBranchQuota(1500);
-        inline for (std.meta.fields(Tag)) |field| {
-            if (field.value == @enumToInt(msg.tag)) {
-                const info = @field(messages, field.name);
-                if (@hasDecl(info, "extra")) {
-                    switch (info.extra) {
-                        .str => m.print(info.msg, .{msg.extra.str}),
-                        .tok_id => m.print(info.msg, .{
-                            msg.extra.tok_id.expected.symbol(),
-                            msg.extra.tok_id.actual.symbol(),
-                        }),
-                        .tok_id_expected => m.print(info.msg, .{msg.extra.tok_id_expected.symbol()}),
-                        .arguments => m.print(info.msg, .{ msg.extra.arguments.expected, msg.extra.arguments.actual }),
-                        .codepoints => m.print(info.msg, .{
-                            msg.extra.codepoints.actual,
-                            msg.extra.codepoints.resembles,
-                        }),
-                        .attr_arg_count => m.print(info.msg, .{
-                            @tagName(msg.extra.attr_arg_count.attribute),
-                            msg.extra.attr_arg_count.expected,
-                        }),
-                        .attr_arg_type => m.print(info.msg, .{
-                            msg.extra.attr_arg_type.expected.toString(),
-                            msg.extra.attr_arg_type.actual.toString(),
-                        }),
-                        .actual_codepoint => m.print(info.msg, .{msg.extra.actual_codepoint}),
-                        .ascii => m.print(info.msg, .{msg.extra.ascii}),
-                        .unsigned => m.print(info.msg, .{msg.extra.unsigned}),
-                        .pow_2_as_string => m.print(info.msg, Pow2String{ .@"0" = switch (msg.extra.pow_2_as_string) {
-                            63 => "9223372036854775808",
-                            64 => "18446744073709551616",
-                            127 => "170141183460469231731687303715884105728",
-                            128 => "340282366920938463463374607431768211456",
-                            else => unreachable,
-                        } }),
-                        .signed => m.print(info.msg, .{msg.extra.signed}),
-                        .attr_enum => m.print(info.msg, .{
-                            @tagName(msg.extra.attr_enum.tag),
-                            Attribute.Formatting.choices(msg.extra.attr_enum.tag),
-                        }),
-                        .ignored_record_attr => m.print(info.msg, .{
-                            @tagName(msg.extra.ignored_record_attr.tag),
-                            @tagName(msg.extra.ignored_record_attr.specifier),
-                        }),
-                        else => @compileError("invalid extra kind " ++ @tagName(info.extra)),
-                    }
-                } else {
-                    m.write(info.msg);
-                }
-
-                if (@hasDecl(info, "opt")) {
-                    if (msg.kind == .@"error" and info.kind != .@"error") {
-                        m.print(" [-Werror,-W{s}]", .{info.opt});
-                    } else if (msg.kind != .note) {
-                        m.print(" [-W{s}]", .{info.opt});
-                    }
-                }
-            }
-        }
-
-        m.end(line, width, end_with_splice);
+        renderExtraItem(comp, m, msg);
     }
     const w_s: []const u8 = if (warnings == 1) "" else "s";
     const e_s: []const u8 = if (errors == 1) "" else "s";
@@ -2307,6 +2222,95 @@ pub fn renderExtra(comp: *Compilation, m: anytype) void {
 
     comp.diag.list.items.len = 0;
     comp.diag.errors += errors;
+}
+
+pub fn renderExtraItem(comp: *Compilation, m: anytype, msg: Message) void {
+    var line: ?[]const u8 = null;
+    var end_with_splice = false;
+    const width = if (msg.loc.id != .unused) blk: {
+        var loc = msg.loc;
+        switch (msg.tag) {
+            .escape_sequence_overflow,
+            .invalid_universal_character,
+            .non_standard_escape_char,
+            // use msg.extra.unsigned for index into string literal
+            => loc.byte_offset += @truncate(u32, msg.extra.unsigned),
+            else => {},
+        }
+        const source = comp.getSource(loc.id);
+        var line_col = source.lineCol(loc);
+        line = line_col.line;
+        end_with_splice = line_col.end_with_splice;
+        if (msg.tag == .backslash_newline_escape) {
+            line = line_col.line[0 .. line_col.col - 1];
+            line_col.col += 1;
+            line_col.width += 1;
+        }
+        m.location(source.path, line_col.line_no, line_col.col);
+        break :blk line_col.width;
+    } else 0;
+
+    m.start(msg.kind);
+    @setEvalBranchQuota(1500);
+    inline for (std.meta.fields(Tag)) |field| {
+        if (field.value == @enumToInt(msg.tag)) {
+            const info = @field(messages, field.name);
+            if (@hasDecl(info, "extra")) {
+                switch (info.extra) {
+                    .str => m.print(info.msg, .{msg.extra.str}),
+                    .tok_id => m.print(info.msg, .{
+                        msg.extra.tok_id.expected.symbol(),
+                        msg.extra.tok_id.actual.symbol(),
+                    }),
+                    .tok_id_expected => m.print(info.msg, .{msg.extra.tok_id_expected.symbol()}),
+                    .arguments => m.print(info.msg, .{ msg.extra.arguments.expected, msg.extra.arguments.actual }),
+                    .codepoints => m.print(info.msg, .{
+                        msg.extra.codepoints.actual,
+                        msg.extra.codepoints.resembles,
+                    }),
+                    .attr_arg_count => m.print(info.msg, .{
+                        @tagName(msg.extra.attr_arg_count.attribute),
+                        msg.extra.attr_arg_count.expected,
+                    }),
+                    .attr_arg_type => m.print(info.msg, .{
+                        msg.extra.attr_arg_type.expected.toString(),
+                        msg.extra.attr_arg_type.actual.toString(),
+                    }),
+                    .actual_codepoint => m.print(info.msg, .{msg.extra.actual_codepoint}),
+                    .ascii => m.print(info.msg, .{msg.extra.ascii}),
+                    .unsigned => m.print(info.msg, .{msg.extra.unsigned}),
+                    .pow_2_as_string => m.print(info.msg, Pow2String{ .@"0" = switch (msg.extra.pow_2_as_string) {
+                        63 => "9223372036854775808",
+                        64 => "18446744073709551616",
+                        127 => "170141183460469231731687303715884105728",
+                        128 => "340282366920938463463374607431768211456",
+                        else => unreachable,
+                    } }),
+                    .signed => m.print(info.msg, .{msg.extra.signed}),
+                    .attr_enum => m.print(info.msg, .{
+                        @tagName(msg.extra.attr_enum.tag),
+                        Attribute.Formatting.choices(msg.extra.attr_enum.tag),
+                    }),
+                    .ignored_record_attr => m.print(info.msg, .{
+                        @tagName(msg.extra.ignored_record_attr.tag),
+                        @tagName(msg.extra.ignored_record_attr.specifier),
+                    }),
+                    else => @compileError("invalid extra kind " ++ @tagName(info.extra)),
+                }
+            } else {
+                m.write(info.msg);
+            }
+
+            if (@hasDecl(info, "opt")) {
+                if (msg.kind == .@"error" and info.kind != .@"error") {
+                    m.print(" [-Werror,-W{s}]", .{info.opt});
+                } else if (msg.kind != .note) {
+                    m.print(" [-W{s}]", .{info.opt});
+                }
+            }
+        }
+    }
+    m.end(line, width, end_with_splice);
 }
 
 fn tagKind(diag: *Diagnostics, tag: Tag) Kind {
@@ -2357,12 +2361,12 @@ const MsgWriter = struct {
         };
     }
 
-    fn deinit(m: *MsgWriter) void {
+    pub fn deinit(m: *MsgWriter) void {
         m.w.flush() catch {};
         std.debug.getStderrMutex().unlock();
     }
 
-    fn print(m: *MsgWriter, comptime fmt: []const u8, args: anytype) void {
+    pub fn print(m: *MsgWriter, comptime fmt: []const u8, args: anytype) void {
         m.w.writer().print(fmt, args) catch {};
     }
 

--- a/src/Type.zig
+++ b/src/Type.zig
@@ -881,12 +881,24 @@ pub fn alignof(ty: Type, comp: *const Compilation) u29 {
             else => if (comp.target.cpu.arch == .msp430) @as(u29, 2) else 4,
         },
 
-        .long_long, .ulong_long, .complex_long_long, .complex_ulong_long => if (comp.target.cpu.arch == .msp430) @as(u29, 2) else 8,
+        .long_long, .ulong_long, .complex_long_long, .complex_ulong_long => switch (comp.target.cpu.arch) {
+            .msp430 => 2,
+            .i386 => 4,
+            else => 8,
+        },
         .int128, .uint128, .complex_int128, .complex_uint128 => 16,
         .fp16, .complex_fp16 => 2,
         .float, .complex_float => if (comp.target.cpu.arch == .msp430) @as(u29, 2) else 4,
-        .double, .complex_double => if (comp.target.cpu.arch == .msp430) @as(u29, 2) else 8,
-        .long_double, .complex_long_double => if (comp.target.cpu.arch == .msp430) @as(u29, 2) else 16,
+        .double, .complex_double => switch (comp.target.cpu.arch) {
+            .msp430 => 2,
+            .i386 => 4,
+            else => 8,
+        },
+        .long_double, .complex_long_double => switch (comp.target.cpu.arch) {
+            .msp430 => 2,
+            .i386 => 4,
+            else => 16,
+        },
         .float80, .complex_float80, .float128, .complex_float128 => 16,
         .pointer,
         .decayed_array,

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -44,7 +44,7 @@ const ExpectedFailure = struct {
     extra: bool = false,
     offset: bool = false,
 
-    fn any(self: *const ExpectedFailure) bool {
+    fn any(self: ExpectedFailure) bool {
         return self.parse or self.layout or self.extra or self.offset;
     }
 };
@@ -245,53 +245,54 @@ fn singleRun(alloc: std.mem.Allocator, path: []const u8, source: []const u8, tes
         return;
     }
 
-    var actual = ExpectedFailure{};
-    std.debug.assert(!actual.any());
-    for (comp.diag.list.items) |msg| {
-        switch (msg.kind) {
-            .@"fatal error", .@"error" => {},
-            else => continue,
-        }
-        const src = comp.getSource(msg.loc.id);
-        const line = src.lineCol(msg.loc).line;
-        if (std.ascii.indexOfIgnoreCase(line, "_Static_assert") != null) {
-            // zig fmt: off
-            if (std.ascii.indexOfIgnoreCase(line, "_extra_") != null) actual.extra = true 
-            else if (std.ascii.indexOfIgnoreCase(line, "_bitoffsetof") != null) actual.offset = true
-            else if (std.ascii.indexOfIgnoreCase(line, "sizeof") != null)  actual.layout = true
-            else if (std.ascii.indexOfIgnoreCase(line, "_alignof") != null)  actual.layout = true
-            else actual.parse = true; // should be unreachable.
-            // zig fmt: on
-        } else {
-            actual.parse = true;
-        }
-    }
-
     var buf: [128]u8 = undefined;
     var buf_strm = std.io.fixedBufferStream(&buf);
     try buf_strm.writer().print("{s}|{s}", .{ test_case.target, test_name });
 
-    if (compErr.get(buf[0..buf_strm.pos])) |err| {
-        if (comp.langopts.emulate == .msvc) actual.extra = err.extra;
-        if (!std.meta.eql(actual, err)) {
-            state.progress.log("\nactual failures don't match expected failures.\n\tactual  :{any}\n\texpected:{any}\n", .{ actual, err });
-            comp.renderErrors();
-            state.fail_count += 1;
-        } else {
-            state.skip_count += 1;
+    const expected = compErr.get(buf[0..buf_strm.pos]) orelse ExpectedFailure{};
+
+    if (comp.diag.list.items.len == 0 and expected.any()) {
+        state.progress.log("\nTest Passed when failures expected:\n\texpected:{any}\n", .{expected});
+    } else {
+        var m = aro.Diagnostics.defaultMsgWriter(&comp);
+        defer m.deinit();
+        var expectedErrors = false;
+        var newError = false;
+        for (comp.diag.list.items) |msg| {
+            switch (msg.kind) {
+                .@"fatal error", .@"error" => {},
+                else => continue,
+            }
+            const src = comp.getSource(msg.loc.id);
+            const line = src.lineCol(msg.loc).line;
+            var render = false;
+            if (std.ascii.indexOfIgnoreCase(line, "_Static_assert") != null) {
+                if (std.ascii.indexOfIgnoreCase(line, "_extra_") != null) {
+                    // MSVC _extra_ tests are all assumed to fail atm.
+                    if (comp.langopts.emulate == .msvc or expected.extra) expectedErrors = true else render = true;
+                } else if (std.ascii.indexOfIgnoreCase(line, "_bitoffsetof") != null) {
+                    if (!expected.offset) render = true else expectedErrors = true;
+                } else if (std.ascii.indexOfIgnoreCase(line, "sizeof") != null or
+                    std.ascii.indexOfIgnoreCase(line, "_alignof") != null)
+                {
+                    if (!expected.layout) render = true else expectedErrors = true;
+                } else unreachable;
+            } else if (!expected.parse) render = true else expectedErrors = true;
+
+            if (render) {
+                if (!newError) m.print("\n", .{});
+                aro.Diagnostics.renderExtraItem(&comp, &m, msg);
+                newError = true;
+            }
         }
-        return;
+        if (newError) {
+            state.fail_count += 1;
+        } else if (expectedErrors == true) {
+            state.skip_count += 1;
+        } else {
+            state.ok_count += 1;
+        }
     }
-    // ignore the "extra" tests for MSVC
-    // right now.
-    if (comp.langopts.emulate == .msvc) actual.extra = false;
-    if (actual.any()) {
-        state.progress.log("\nNo errors expected for {s} {s} Found:{any}\n", .{ test_case.target, test_name, actual });
-        comp.renderErrors();
-        state.fail_count += 1;
-        return;
-    }
-    state.ok_count += 1;
 }
 
 /// Get Zig std.Target from string in the arch-cpu-os-abi format.
@@ -348,6 +349,8 @@ fn parseTargetsFromCode(alloc: std.mem.Allocator, source: []const u8) !std.Array
 
         while (parts.next()) |target| {
             if (std.mem.startsWith(u8, target, "END")) break;
+            // skip MinGW targets for now.
+            if (std.ascii.indexOfIgnoreCase(target, "windows-gnu") != null) continue;
             // These point to source, which lives
             // for the life of the test. So should be ok
             try result.append(.{
@@ -1063,19 +1066,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
-            "i386-i386-ios-none:Clang|0002",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "i386-i386-ios-none:Clang|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i386-ios-none:Clang|0018",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i386-ios-none:Clang|0024",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1091,10 +1082,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "i386-i386-ios-none:Clang|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "i386-i386-ios-none:Clang|0067",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
@@ -1103,143 +1090,15 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
-            "i386-i386-ios-none:Clang|0069",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i386-ios-none:Clang|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
             "i386-i386-ios-none:Clang|0083",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i386-ios-none:Clang|0087",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i386-ios-none:Clang|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0002",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0019",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0024",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0054",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0055",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0060",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0061",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "i386-i586-linux-gnu:Gcc|0062",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "i386-i586-linux-gnu:Gcc|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0069",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0087",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-gnu:Gcc|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0002",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0019",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0024",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0054",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0055",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0060",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0061",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "i386-i586-linux-musl:Gcc|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0069",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0087",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i586-linux-musl:Gcc|0088",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1387,99 +1246,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "i386-i686-freebsd-gnu:Clang|0002",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0018",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0024",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0054",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0055",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0060",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0061",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "i386-i686-freebsd-gnu:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0069",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0087",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-freebsd-gnu:Clang|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0002",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0018",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0024",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0054",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0055",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0060",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0061",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1487,119 +1254,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "i386-i686-haiku-gnu:Clang|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0069",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0087",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-haiku-gnu:Clang|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0002",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0018",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0024",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0054",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0055",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0060",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0061",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "i386-i686-linux-android:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0069",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0087",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-android:Clang|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0002",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0019",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0024",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0054",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0055",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0060",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0061",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1607,119 +1262,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "i386-i686-linux-gnu:Gcc|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0069",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0087",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-gnu:Gcc|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0002",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0019",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0024",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0054",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0055",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0060",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0061",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "i386-i686-linux-musl:Gcc|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0069",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0087",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-linux-musl:Gcc|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0002",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0018",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0024",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0054",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0055",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0060",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0061",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -1727,83 +1270,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "i386-i686-netbsd-gnu:Clang|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0069",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0087",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-netbsd-gnu:Clang|0088",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0002",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0013",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0018",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0024",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0043",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0054",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0055",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0060",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0061",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "i386-i686-openbsd-gnu:Clang|0062",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0068",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0069",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0082",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0087",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "i386-i686-openbsd-gnu:Clang|0088",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -256,8 +256,8 @@ fn singleRun(alloc: std.mem.Allocator, path: []const u8, source: []const u8, tes
     } else {
         var m = aro.Diagnostics.defaultMsgWriter(&comp);
         defer m.deinit();
-        var expectedErrors = false;
-        var newError = false;
+        var expected_errors = false;
+        var new_error = false;
         for (comp.diag.list.items) |msg| {
             switch (msg.kind) {
                 .@"fatal error", .@"error" => {},
@@ -269,25 +269,25 @@ fn singleRun(alloc: std.mem.Allocator, path: []const u8, source: []const u8, tes
             if (std.ascii.indexOfIgnoreCase(line, "_Static_assert") != null) {
                 if (std.ascii.indexOfIgnoreCase(line, "_extra_") != null) {
                     // MSVC _extra_ tests are all assumed to fail atm.
-                    if (comp.langopts.emulate == .msvc or expected.extra) expectedErrors = true else render = true;
+                    if (comp.langopts.emulate == .msvc or expected.extra) expected_errors = true else render = true;
                 } else if (std.ascii.indexOfIgnoreCase(line, "_bitoffsetof") != null) {
-                    if (!expected.offset) render = true else expectedErrors = true;
+                    if (!expected.offset) render = true else expected_errors = true;
                 } else if (std.ascii.indexOfIgnoreCase(line, "sizeof") != null or
                     std.ascii.indexOfIgnoreCase(line, "_alignof") != null)
                 {
-                    if (!expected.layout) render = true else expectedErrors = true;
+                    if (!expected.layout) render = true else expected_errors = true;
                 } else unreachable;
-            } else if (!expected.parse) render = true else expectedErrors = true;
+            } else if (!expected.parse) render = true else expected_errors = true;
 
             if (render) {
-                if (!newError) m.print("\n", .{});
+                if (!new_error) m.print("\n", .{});
                 aro.Diagnostics.renderExtraItem(&comp, &m, msg);
-                newError = true;
+                new_error = true;
             }
         }
-        if (newError) {
+        if (new_error) {
             state.fail_count += 1;
-        } else if (expectedErrors == true) {
+        } else if (expected_errors) {
             state.skip_count += 1;
         } else {
             state.ok_count += 1;


### PR DESCRIPTION

This updates the tests for the new 32-bit align code.
It also does not print `_extra_` assert errors for MSVC targets.
It skips MinGW targets.

This patch does still error on 32-bit MSVC that this fix changed. 