### PR TITLE
TypeStore: round record size up to alignment for MSVC

### DIFF
--- a/src/aro/TypeStore.zig
+++ b/src/aro/TypeStore.zig
@@ -610,7 +610,20 @@ pub const QualType = packed struct(u32) {
             },
             .@"struct", .@"union" => |record| {
                 const layout = record.layout orelse return null;
-                return layout.size_bits / 8;
+                const size = layout.size_bits / 8;
+                if (comp.langopts.emulate != .msvc) return size;
+                const alignment = qt.requestedAlignment(comp) orelse return size;
+
+                const should_round_size = switch (qt.type(comp)) {
+                    .typedef => |typedef| switch (typedef.base.type(comp)) {
+                        .@"struct", .@"union" => true,
+                        else => false,
+                    },
+                    else => true,
+                };
+                if (!should_round_size) return size;
+
+                return std.mem.alignForward(u64, size, alignment);
             },
             .@"enum" => |enum_ty| {
                 const tag = enum_ty.tag orelse return null;

--- a/test/cases/alignment on typedef msvc.c
+++ b/test/cases/alignment on typedef msvc.c
@@ -36,6 +36,13 @@ __declspec(align(16)) typedef enum {
 
 _Static_assert(_Alignof(AlignedEnum) == 16, "");
 
+typedef struct __declspec(align(16)) {
+  int x;
+} AlignedStruct;
+
+_Static_assert(_Alignof(AlignedStruct) == 16, "");
+_Static_assert(sizeof(AlignedStruct) == 16, "");
+
 /** manifest:
 syntax
 args = -target x86_64-windows-msvc

--- a/test/record_runner.zig
+++ b/test/record_runner.zig
@@ -342,19 +342,7 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
-            "aarch64-generic-windows-msvc:Msvc|0023",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0025",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "aarch64-generic-windows-msvc:Msvc|0026",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0029",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -370,10 +358,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
-            "aarch64-generic-windows-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "aarch64-generic-windows-msvc:Msvc|0045",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -383,14 +367,6 @@ const compErr = blk: {
         },
         .{
             "aarch64-generic-windows-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0065",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "aarch64-generic-windows-msvc:Msvc|0066",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -406,14 +382,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0023",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0025",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i586-windows-msvc:Msvc|0026",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
@@ -422,12 +390,12 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0042",
-            .{ .parse = false, .layout = true, .extra = true, .offset = true },
+            "aarch64-generic-windows-msvc:Msvc|0029",
+            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
+            "x86-i586-windows-msvc:Msvc|0042",
+            .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
             "x86-i586-windows-msvc:Msvc|0045",
@@ -442,24 +410,8 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i586-windows-msvc:Msvc|0065",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i586-windows-msvc:Msvc|0066",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i686-uefi-msvc:Msvc|0018",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0023",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0025",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86-i686-uefi-msvc:Msvc|0026",
@@ -474,10 +426,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
-            "x86-i686-uefi-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i686-uefi-msvc:Msvc|0045",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -490,24 +438,8 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86-i686-uefi-msvc:Msvc|0065",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-uefi-msvc:Msvc|0066",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i686-windows-msvc:Msvc|0018",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0023",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0025",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86-i686-windows-msvc:Msvc|0026",
@@ -522,10 +454,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
-            "x86-i686-windows-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86-i686-windows-msvc:Msvc|0045",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -535,14 +463,6 @@ const compErr = blk: {
         },
         .{
             "x86-i686-windows-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0065",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86-i686-windows-msvc:Msvc|0066",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -556,14 +476,6 @@ const compErr = blk: {
         .{
             "thumb-baseline-windows-msvc:Msvc|0021",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0023",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0025",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "thumb-baseline-windows-msvc:Msvc|0026",
@@ -586,10 +498,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
-            "thumb-baseline-windows-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "thumb-baseline-windows-msvc:Msvc|0045",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -599,14 +507,6 @@ const compErr = blk: {
         },
         .{
             "thumb-baseline-windows-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0065",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "thumb-baseline-windows-msvc:Msvc|0066",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
@@ -622,14 +522,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0023",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0025",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86_64-x86_64-uefi-msvc:Msvc|0026",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
@@ -640,10 +532,6 @@ const compErr = blk: {
         .{
             "x86_64-x86_64-uefi-msvc:Msvc|0042",
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-uefi-msvc:Msvc|0045",
@@ -658,24 +546,8 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0065",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-uefi-msvc:Msvc|0066",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86_64-x86_64-windows-msvc:Msvc|0018",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0023",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0025",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0026",
@@ -690,10 +562,6 @@ const compErr = blk: {
             .{ .parse = false, .layout = true, .extra = true, .offset = true },
         },
         .{
-            "x86_64-x86_64-windows-msvc:Msvc|0044",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
             "x86_64-x86_64-windows-msvc:Msvc|0045",
             .{ .parse = false, .layout = false, .extra = true, .offset = false },
         },
@@ -703,14 +571,6 @@ const compErr = blk: {
         },
         .{
             "x86_64-x86_64-windows-msvc:Msvc|0063",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0065",
-            .{ .parse = false, .layout = true, .extra = true, .offset = false },
-        },
-        .{
-            "x86_64-x86_64-windows-msvc:Msvc|0066",
             .{ .parse = false, .layout = true, .extra = true, .offset = false },
         },
     });


### PR DESCRIPTION
This regresses 3 record tests but brings the overall number of failing ones down to 61. I targeted the msvc-enum branch just to avoid conflicts, #1067 should be merged first.